### PR TITLE
Support for Ints & Floats in Enums

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,8 @@
 ## v0.0.1 (6th April 2022)
 
 * Initial release of the Yamlator package
+
+## v0.0.2 (TBC)
+
+* Added a `Regex` type to the schema to support regex validation
+* Added support for `integers` and `floats` in the `Enum` construct

--- a/docs/schema_components.md
+++ b/docs/schema_components.md
@@ -139,7 +139,7 @@ ruleset <ruleset-name> {
 }
 ```
 
-The regex type can also be nested in the `map` or `list` types. For example, when applied to a list allows for a collection of strings to be validated:
+The regex type can also be nested in the `map` or `list` types. For example, when applied to a list, it allows for a collection of strings to be validated:
 
 ```yaml
 roles:
@@ -148,7 +148,7 @@ roles:
     - role/editor
 ```
 
-With the following rule in a schema block:
+Then the rule within a schema block:
 
 ```text
 schema {
@@ -158,7 +158,7 @@ schema {
 
 ### Ruleset Type
 
-Rulesets can be referenced as a type to validate complicated YAML structures. For example, if the following YAML data existed:
+Rulesets can be referenced as a type to validate complex YAML structures. For example, if the following YAML data existed:
 
 ```yaml
 project:
@@ -204,7 +204,7 @@ schema {
 
 ### Enum Type
 
-Enums can be used to define string constant in a schema. This can be used to enforce specific string values in the YAML data. An enum must start with a capital letter. A enum can be defined with:
+Enums can be used to define a collection of string, integer and float constants. An enum name must start with a capital letter. A enum can be defined with:
 
 ```text
 enum <enum-name> {
@@ -212,13 +212,22 @@ enum <enum-name> {
 }
 ```
 
-For example, a enum for log levels could be:
+For example, a enum of string constants for log levels:
 
 ```text
 enum LogLevel {
-    ERR = error
-    INFO = info
-    DEBUG = debug
+    ERR = "error"
+    INFO = "info"
+    DEBUG = "debug"
+}
+```
+
+An example of an enum with integers and floats:
+
+```text
+enum Numbers {
+    LIFE = 42
+    PI = 3.142
 }
 ```
 

--- a/docs/schema_components.md
+++ b/docs/schema_components.md
@@ -148,7 +148,7 @@ roles:
     - role/editor
 ```
 
-Then the rule within a schema block:
+Then the following rule within a schema block can be used to validate this list:
 
 ```text
 schema {

--- a/example/project.yaml
+++ b/example/project.yaml
@@ -1,6 +1,5 @@
 project:
   version: v1
-  status: created
   projectId: my-test-project
   displayName: my-test-project
   iam_permission:

--- a/example/project.yaml
+++ b/example/project.yaml
@@ -1,5 +1,6 @@
 project:
   version: v1
+  status: created
   projectId: my-test-project
   displayName: my-test-project
   iam_permission:

--- a/example/project.ys
+++ b/example/project.ys
@@ -1,7 +1,7 @@
 enum Status {
-    CREATED = created
-    ACTIVE = active
-    DELETED = deleted
+    CREATED = "created"
+    ACTIVE = "active"
+    DELETED = "deleted"
 }
 
 ruleset Details {

--- a/src/grammer/grammer.lark
+++ b/src/grammer/grammer.lark
@@ -9,7 +9,8 @@ start: instructions*
 schema_entry: "schema" "{" rule+ "}"
 ruleset: "ruleset" /[A-Z]{1}[a-z0-9_]+/ "{" rule+ "}"
 enum: "enum" /[A-Z]{1}[a-z0-9_]+/ "{" enum_item+ "}"
-enum_item: /[A-Z0-9_]+/ "=" /[A-Za-z0-9_]+/
+enum_item: /[A-Z0-9_]+/ "=" ESCAPED_STRING
+         | /[A-Z0-9_]+/ "=" NUMBER
 
 // Rule Definitions
 ?rule: required_rule
@@ -40,8 +41,8 @@ regex_type: "regex""(" ESCAPED_STRING ")"
 
 NEW_LINES: "\n"+
 
-%import common.INT
 %import common.ESCAPED_STRING
+%import common.NUMBER
 %import common.WS
 %ignore WS
 %ignore NEW_LINES

--- a/src/grammer/grammer.lark
+++ b/src/grammer/grammer.lark
@@ -9,8 +9,9 @@ start: instructions*
 schema_entry: "schema" "{" rule+ "}"
 ruleset: "ruleset" /[A-Z]{1}[a-z0-9_]+/ "{" rule+ "}"
 enum: "enum" /[A-Z]{1}[a-z0-9_]+/ "{" enum_item+ "}"
-enum_item: /[A-Z0-9_]+/ "=" ESCAPED_STRING
-         | /[A-Z0-9_]+/ "=" NUMBER
+enum_item: /[A-Z0-9_]+/ "=" INT
+         | /[A-Z0-9_]+/ "=" FLOAT
+         | /[A-Z0-9_]+/ "=" ESCAPED_STRING
 
 // Rule Definitions
 ?rule: required_rule
@@ -41,8 +42,11 @@ regex_type: "regex""(" ESCAPED_STRING ")"
 
 NEW_LINES: "\n"+
 
+%import common.SH_COMMENT
 %import common.ESCAPED_STRING
-%import common.NUMBER
+%import common.INT
+%import common.FLOAT
 %import common.WS
 %ignore WS
 %ignore NEW_LINES
+%ignore SH_COMMENT

--- a/src/grammer/grammer.lark
+++ b/src/grammer/grammer.lark
@@ -1,19 +1,22 @@
 // Entry point
 start: instructions*
 
-// Collection data structure Definitions
+// Collection constructs
 ?instructions: enum
             | ruleset
             | schema_entry
 
 schema_entry: "schema" "{" rule+ "}"
+
 ruleset: "ruleset" /[A-Z]{1}[a-z0-9_]+/ "{" rule+ "}"
+
+// Enum constructs
 enum: "enum" /[A-Z]{1}[a-z0-9_]+/ "{" enum_item+ "}"
 enum_item: /[A-Z0-9_]+/ "=" INT
          | /[A-Z0-9_]+/ "=" FLOAT
          | /[A-Z0-9_]+/ "=" ESCAPED_STRING
 
-// Rule Definitions
+// Rule definitions
 ?rule: required_rule
      | optional_rule
 
@@ -47,6 +50,7 @@ NEW_LINES: "\n"+
 %import common.INT
 %import common.FLOAT
 %import common.WS
+
 %ignore WS
 %ignore NEW_LINES
 %ignore SH_COMMENT

--- a/src/parser.py
+++ b/src/parser.py
@@ -147,11 +147,7 @@ class SchemaTransformer(Transformer):
     def enum_item(self, tokens: Any) -> EnumItem:
         """Transforms a enum item token into a EnumItem object"""
         name, value = tokens
-
-        # Remove the speech marks from the value
-        value = value.value
-        value = value[1:len(value) - 1]
-        return EnumItem(name=name.value, value=value)
+        return EnumItem(name=name, value=value)
 
     def enum(self, tokens: Any) -> YamlatorEnum:
         """Transforms a enum token into a YamlatorEnum object"""
@@ -180,9 +176,7 @@ class SchemaTransformer(Transformer):
     def regex_type(self, tokens: Any) -> RuleType:
         """Transforms a regex type token into a RuleType object"""
         (regex, ) = tokens
-        regex_str = regex.value
-        regex_str = regex_str[1: len(regex_str) - 1]
-        return RuleType(type=SchemaTypes.REGEX, regex=regex_str)
+        return RuleType(type=SchemaTypes.REGEX, regex=regex)
 
     def type(self, tokens: Any) -> Any:
         """Extracts the type tokens and passes them through onto
@@ -190,6 +184,16 @@ class SchemaTransformer(Transformer):
         """
         (t, ) = tokens
         return t
+
+    def INT(self, token):
+        return int(token)
+
+    def FLOAT(self, token):
+        return float(token)
+
+    def ESCAPED_STRING(self, token):
+        token = token[1:len(token) - 1]
+        return token
 
     def schema_entry(self, rules: list) -> YamlatorRuleset:
         """Transforms the schema entry point token into a YamlatorRuleset called

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 import os
+
 from pathlib import Path
 from typing import Iterator
 from lark import Lark
@@ -23,6 +25,8 @@ from src.exceptions import SchemaParseError
 
 _package_dir = Path(__file__).parent.absolute()
 _GRAMMER_FILE = os.path.join(_package_dir, 'grammer/grammer.lark')
+
+_SPEECH_MARKS_REGEX = re.compile(r'\"|\'')
 
 
 def parse_schema(schema_content: str) -> dict:
@@ -185,21 +189,23 @@ class SchemaTransformer(Transformer):
         (t, ) = tokens
         return t
 
-    def INT(self, token):
-        return int(token)
-
-    def FLOAT(self, token):
-        return float(token)
-
-    def ESCAPED_STRING(self, token):
-        token = token[1:len(token) - 1]
-        return token
-
     def schema_entry(self, rules: list) -> YamlatorRuleset:
         """Transforms the schema entry point token into a YamlatorRuleset called
         main that will act as the entry point for validaiting the YAML data
         """
         return YamlatorRuleset('main', rules)
+
+    def INT(self, token: str) -> int:
+        """Convers a integer string into a int type"""
+        return int(token)
+
+    def FLOAT(self, token: str) -> float:
+        """Convers a float string into a int type"""
+        return float(token)
+
+    def ESCAPED_STRING(self, token: str) -> str:
+        """Transforms the escaped string by removing speech marks from the value"""
+        return _SPEECH_MARKS_REGEX.sub('', token)
 
 
 class _InstructionHandler:

--- a/src/parser.py
+++ b/src/parser.py
@@ -147,7 +147,11 @@ class SchemaTransformer(Transformer):
     def enum_item(self, tokens: Any) -> EnumItem:
         """Transforms a enum item token into a EnumItem object"""
         name, value = tokens
-        return EnumItem(name=name.value, value=value.value)
+
+        # Remove the speech marks from the value
+        value = value.value
+        value = value[1:len(value) - 1]
+        return EnumItem(name=name.value, value=value)
 
     def enum(self, tokens: Any) -> YamlatorEnum:
         """Transforms a enum token into a YamlatorEnum object"""

--- a/src/validators.py
+++ b/src/validators.py
@@ -464,8 +464,8 @@ class EnumTypeValidator(Validator):
             super().validate(key, data, parent, rtype, is_required)
             return
 
-        is_enum_str_data = isinstance(data, str)
-        if not is_enum_str_data:
+        is_enum_data = isinstance(data, (str, float, int))
+        if not is_enum_data:
             self._add_enum_violation(key, parent, rtype.lookup)
             return
 
@@ -476,9 +476,9 @@ class EnumTypeValidator(Validator):
 
     def _matches_enum_data(self, data: Data, enum_name: str) -> bool:
         target_enum = self.enums.get(enum_name, None)
-
         if target_enum is None:
             return False
+
         enum_value = target_enum.items.get(data, None)
         return enum_value is not None
 

--- a/src/validators.py
+++ b/src/validators.py
@@ -479,7 +479,6 @@ class EnumTypeValidator(Validator):
 
         if target_enum is None:
             return False
-
         enum_value = target_enum.items.get(data, None)
         return enum_value is not None
 

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -102,14 +102,18 @@ class TestSchemaTransformer(unittest.TestCase):
         self.assertEqual(SchemaTypes.ANY, any_type.type)
 
     def test_enum_item(self):
+        expected_enum_val = "success"
         enum_name = Token('StatusCode')
-        enum_value = Token('success')
+
+        # Additional speech marks are added to align with how
+        # lark would transform this string
+        enum_value = Token('"success"')
 
         tokens = (enum_name, enum_value)
         enum_item = self.transformer.enum_item(tokens)
 
         self.assertEqual(enum_name.value, enum_item.name)
-        self.assertEqual(enum_value.value, enum_item.value)
+        self.assertEqual(expected_enum_val, enum_item.value)
 
     def test_enum(self):
         enum_items = [

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -163,6 +163,26 @@ class TestSchemaTransformer(unittest.TestCase):
         self.assertEqual(expected_ruleset_name, ruleset.name)
         self.assertEqual(len(self.ruleset_rules), len(ruleset.rules))
 
+    def test_int_transform(self):
+        expected_value = 42
+        actual_value = self.transformer.INT("42")
+        self.assertEqual(expected_value, actual_value)
+
+    def test_float_transform(self):
+        expected_value = 3.142
+        actual_value = self.transformer.FLOAT("3.142")
+        self.assertEqual(expected_value, actual_value)
+
+    @parameterized.expand([
+        ('string_with_double_speech_marks', '\"hello\"', 'hello'),
+        ('string_with_single_speech_marks', '\'hello\'', 'hello'),
+        ('string_without_speech_marks', 'hello', 'hello'),
+        ('empty_string', '', '')
+    ])
+    def test_escaped_string_transform(self, name: str, string_token: str, expected: str):
+        actual = self.transformer.ESCAPED_STRING(string_token)
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -102,18 +102,14 @@ class TestSchemaTransformer(unittest.TestCase):
         self.assertEqual(SchemaTypes.ANY, any_type.type)
 
     def test_enum_item(self):
-        expected_enum_val = "success"
-        enum_name = Token('StatusCode')
-
-        # Additional speech marks are added to align with how
-        # lark would transform this string
-        enum_value = Token('"success"')
+        enum_name = 'StatusCode'
+        enum_value = 'success'
 
         tokens = (enum_name, enum_value)
         enum_item = self.transformer.enum_item(tokens)
 
-        self.assertEqual(enum_name.value, enum_item.name)
-        self.assertEqual(expected_enum_val, enum_item.value)
+        self.assertEqual(enum_name, enum_item.name)
+        self.assertEqual(enum_value, enum_item.value)
 
     def test_enum(self):
         enum_items = [
@@ -148,7 +144,7 @@ class TestSchemaTransformer(unittest.TestCase):
             self.transformer.container_type(token)
 
     def test_regex_type(self):
-        token = Token("\"test{1}\"")
+        token = "test{1}"
         expected_regex_str = re.compile("test{1}")
 
         rule_type = self.transformer.regex_type((token, ))

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -130,13 +130,13 @@ class TestSchemaTransformer(unittest.TestCase):
         self.assertEqual(rule.type, SchemaTypes.RULESET)
 
     @parameterized.expand([
-        ('with_existing_constructs', 'Employee', {
+        ('with_existing_constructs', {
             'Details': SchemaTypes.RULESET,
             'Status': SchemaTypes.ENUM
         }),
-        ('without_existing_constructs', 'Employee', {})
+        ('without_existing_constructs', {})
     ])
-    def test_container_type_construct_does_not_exist(self, name: str, construct_name: str,
+    def test_container_type_construct_does_not_exist(self, name: str,
                                                      seen_constructs: dict):
         token = Token(name)
         self.transformer.seen_constructs = seen_constructs


### PR DESCRIPTION
# Changes

* Updated the grammer to support `ints` and `floats` in an Enum
* Updated the grammer to allow comments within the schema file
* Updated the transformer to process the `INT`, `FLOAT` and `ESCAPED_STRING` terminals
* Updated the Enum documentation to include this change
* Updated `changelog.md` with the list of changes so far for `v0.0.2`