### PR TITLE
Ruleset & Enum construct name fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/Ryan95Z/yamlator)](https://github.com/Ryan95Z/yamlator/blob/main/LICENSE)
 [![PyPi Version](https://img.shields.io/pypi/v/yamlator)](https://pypi.org/project/yamlator/)
 
-Yamlator is a CLI tool that allows a YAML file to be validated using a lightweight schema that defines the expected structure for the YAML file. When executed, the YAML data is compared against the rules to validate that the relevant keys and data types are present. Once validated, a list of violations will be displayed to help amend the YAML data.
+Yamlator is a CLI tool that allows a YAML file to be validated using a lightweight schema that defines the expected structure. When executed, the YAML is compared against the rules to validate that the relevant keys and data types are present. Once validated, a list of violations will be displayed to help amend the YAML file.
 
 ## Installing the package
 
@@ -19,7 +19,7 @@ pip install yamlator
 
 Schemas in Yamlator are comprised of rules, rulesets and enums, which are defined in a Yamlator schema file with the `.ys` extension.
 
-In the Yamlator schema, the entry point is defined in a `schema` block. As a minimum, a schema block must be defined for Yamlator to validate a file. Complex structures can be defined as `rulesets` to validate nested structures. For example, the following schema can be defined to manage a list of employees:
+In the Yamlator schema file, the entry point is defined in a `schema` block. As a minimum, a schema block must be defined for Yamlator to validate a file. Complex structures can be defined as `rulesets` to validate nested structures. For example, the following schema can be defined to manage a list of employees:
 
 ```text
 ruleset Employee {
@@ -52,11 +52,11 @@ employees:
 
 More information on the different components that can be used in a schema can be found in the [schema components documentation](./docs/schema_components.md).
 
-Additional examples of a schema file with some YAML can be found in the [examples directory](./example/)
+Additional examples of Yamlator schemas can be found in the [examples directory](./example/)
 
 ## How to run the CLI
 
-Assuming you have a YAML and Yamlator file, the CLI can be executed with:
+Assuming you have a YAML and Yamlator schema file, the CLI can be executed with:
 
 ```bash
 yamlator <path-to-yaml-file> -s <path-to-yamlator-schema>
@@ -69,7 +69,7 @@ The first argument for the CLI is always the path to the YAML file.
 | Flag | Alias | Description | Is Required |
 |:-----|:------|:------------|:------------|
 | `--schema` | `-s` | The schema that will be used to validate the YAML file | True |
-| `--output` | `-o` | Defines the format that will be displayed for the violations. Supported values are `table` or `json`. Defaults to `table` if not specified. | False |
+| `--output` | `-o` | Defines the violations format that will be displayed. Supported values are `table` or `json`. Defaults to `table` if not specified. | False |
 
 To see the help options for the CLI, run `yamlator -h` or `yamlator --help`
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 * Initial release of the Yamlator package
 
-## v0.0.2 (TBC)
+## v0.1.0 (TBC)
 
 * Added a `Regex` type to the schema to support regex validation
 * Added support for `integers` and `floats` in the `Enum` construct
+* Fixed bug with the the `Enum` and `Ruleset` construct names that prevented camel case from working

--- a/docs/schema_components.md
+++ b/docs/schema_components.md
@@ -30,11 +30,11 @@ schema {
 }
 ```
 
-Rules in the schema block following the exact same pattern that can be used in `rulesets`. See [rules](#rules) for more information.
+Rules in the schema block follow the exact same pattern that can be used in `rulesets`. See [rules](#rules) for more information.
 
 ## Rulesets
 
-A ruleset allows for complex YAML structures to be defined. A ruleset is made up or 1 or more [rules](#rules). T name of the ruleset must begin with a capital letter followed by lowercase letters, uppercase letters and underscores.
+A ruleset allows for complex YAML structures to be defined. A ruleset is made up of 1 or more [rules](#rules). The name of the ruleset must begin with a capital letter followed by lowercase letters, uppercase letters or underscores.
 
 The following are valid ruleset names:
 
@@ -94,7 +94,7 @@ Required rules validate that the key is present in the YAML data. If the require
 
 ## Rule Types
 
-For each rule, a type can be specified to ensure that data aligns the expect type.
+For each rule, a type can be specified to validate the expected data type is present.
 
 ### Basic Types
 
@@ -107,7 +107,7 @@ For each rule, the following basic types are supported:
 * `list(<type>)` - List type where `<type>` defines the expected type of each item in the list.
 * `map(<type>)` - Map Type where `<type>` defines the expected type of the value.
 
-The list and map types support multiple nested structures which allows for complicated structures to be validated. The `<type>` for a map or list can be a ruleset, enum, any or a basic type.
+The list and map types support multiple nested structures which allows for complicated structures to be validated. The `<type>` for a map or list can be a ruleset, enum, list, map, any, regex or a basic type.
 
 A nested list in a rule can be defined as:
 
@@ -123,7 +123,7 @@ employees map(Employee)
 
 ### Any Type
 
-The `any` type allows for a key to be defined that does not require a type check. When the `any` type key is defind, all type checks are ignored and any data type may be used. When used only the required and optional checks are applied.
+The `any` type allows for a key to be defined that does not require a type check. When the `any` type key is used, all type checks are ignored and any data type may be used in the YAML data. When used only the required and optional checks are applied.
 
 An example of it in a ruleset:
 

--- a/docs/schema_components.md
+++ b/docs/schema_components.md
@@ -2,6 +2,16 @@
 
 Below are the various components that can be used to construct a schema with Yamlator. These constructs must be placed into a `.ys` file.
 
+* [Schema](#schema)
+* [Rulesets](#rulesets)
+* [Rules](#rules)
+* [RuleTypes](#rule-types)
+  * [Basic Types](#basic-types)
+  * [Any Type](#any-type)
+  * [Regex Type](#regex-type)
+  * [Ruleset Type](#ruleset-type)
+* [Enums](#enums)
+
 ## Schema
 
 A schema block defines the entry point that will be used during the validation process. Within the block a list of rules can be defined to indicate the root keys of a YAML file. For example, given the following YAML data:
@@ -24,7 +34,15 @@ Rules in the schema block following the exact same pattern that can be used in `
 
 ## Rulesets
 
-A ruleset allows for complex YAML structures to be defined. A ruleset is made up or 1 or more [rules](#rules) and the name of the ruleset must begin with a capital letter.
+A ruleset allows for complex YAML structures to be defined. A ruleset is made up or 1 or more [rules](#rules). T name of the ruleset must begin with a capital letter followed by lowercase letters, uppercase letters and underscores.
+
+The following are valid ruleset names:
+
+* `Employee`
+* `EmployeeDetails`
+* `Employee_Details`
+* `Employeedetails`
+* `Employee_details`
 
 Below is the basic definition of a user defined ruleset:
 
@@ -76,7 +94,7 @@ Required rules validate that the key is present in the YAML data. If the require
 
 ## Rule Types
 
-For each rule, a type can be specified to ensure that data meet the expect type.
+For each rule, a type can be specified to ensure that data aligns the expect type.
 
 ### Basic Types
 
@@ -203,9 +221,19 @@ schema {
 }
 ```
 
-### Enum Type
+## Enums
 
-Enums can be used to define a collection of string, integer and float constants. An enum name must start with a capital letter. A enum can be defined with:
+Enums can be used to define a collection of string, integer and float constants. An enum name must start with a capital letter followed by lowercase letters, uppercase letters or underscores.
+
+The following are valid enum names:
+
+* `Status`
+* `EmployeeStatus`
+* `Employee_Status`
+* `Employeestatus`
+* `Employee_status`
+
+A enum can be defined with:
 
 ```text
 enum <enum-name> {

--- a/docs/setting_up_the_environment.md
+++ b/docs/setting_up_the_environment.md
@@ -8,7 +8,7 @@ The project requires the following:
 
 ## Creating the virtual environment
 
-Before creating a virtual environment, ensure that the virtualenv package has been installed. This can be added to Python with:
+Before creating a virtual environment, ensure that the `virtualenv` package has been installed. This can be installed with:
 
 ```bash
 pip install virtualenv
@@ -17,7 +17,7 @@ pip install virtualenv
 Once `virtualenv` has been installed. A new virtual environment can be created with:
 
 ```bash
-python -m venv env
+python3 -m venv env
 ```
 
 Then activate the virtual environment with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [pycodestyle]
 exclude=env/
 max-line-length=90
+[metadata]
+license_file=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
     version=VERSION,
     description=DESCRIPTION,
     long_description=long_description,
+    license='MIT',
     long_description_content_type='text/markdown',
     url='https://github.com/Ryan95Z/yamlator',
     author='Ryan Flynn',

--- a/src/grammer/grammer.lark
+++ b/src/grammer/grammer.lark
@@ -8,10 +8,10 @@ start: instructions*
 
 schema_entry: "schema" "{" rule+ "}"
 
-ruleset: "ruleset" /[A-Z]{1}[a-z0-9_]+/ "{" rule+ "}"
+ruleset: "ruleset" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" rule+ "}"
 
 // Enum constructs
-enum: "enum" /[A-Z]{1}[a-z0-9_]+/ "{" enum_item+ "}"
+enum: "enum" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" enum_item+ "}"
 enum_item: /[A-Z0-9_]+/ "=" INT
          | /[A-Z0-9_]+/ "=" FLOAT
          | /[A-Z0-9_]+/ "=" ESCAPED_STRING
@@ -42,7 +42,7 @@ float_type: "float"
 bool_type: "bool"
 list_type: "list""(" type ")"
 map_type: "map""(" type ")"
-container_type: /[A-Z]{1}[a-z0-9_]+/
+container_type: /[A-Z]{1}[a-zA-Z0-9_]+/
 regex_type: "regex""(" ESCAPED_STRING ")"
 
 NEW_LINES: "\n"+

--- a/tests/files/example/example.yaml
+++ b/tests/files/example/example.yaml
@@ -1,2 +1,6 @@
 message: hello world
 number: 42
+person:
+  name: Test Tester
+  age: 42
+  isEmployed: true

--- a/tests/files/example/example.yaml
+++ b/tests/files/example/example.yaml
@@ -4,3 +4,4 @@ person:
   name: Test Tester
   age: 42
   isEmployed: true
+  department: lead

--- a/tests/files/example/example.ys
+++ b/tests/files/example/example.ys
@@ -1,4 +1,25 @@
+# Test the use of underscores
+enum Employee_department {
+    MANAGER = "manager"
+    LEAD = "lead"
+}
+
+ruleset PersonAddress {
+    houseNumber int
+    street str
+    city str
+    post_code str
+}
+
+ruleset Person {
+    name str
+    age int
+    address PersonAddress optional
+    isEmployed bool
+}
+
 schema {
     message str
     number int
+    person Person optional
 }

--- a/tests/files/example/example.ys
+++ b/tests/files/example/example.ys
@@ -16,6 +16,7 @@ ruleset Person {
     age int
     address PersonAddress optional
     isEmployed bool
+    department Employee_department
 }
 
 schema {


### PR DESCRIPTION
# Changes

* Fixed a bug with the grammer that prevented `Enum` or `Rulesets` from having camel case names
* Minor improvements to the documentation such as including a table of contents on the schema component doc.
* Updated the setup config to include the license
* Updated the changelog for the next version to be `0.1.0`